### PR TITLE
Chore: Update latest to Tika 2.5

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -25,7 +25,7 @@ jobs:
           LATEST: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Prepare
         id: prep
@@ -49,18 +49,18 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@master
+        uses: docker/setup-buildx-action@v2
 
       - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v3
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -72,3 +72,5 @@ jobs:
             TIKA_JAR_NAME=${{ matrix.TIKA_JAR_NAME }}
             CHECK_SIG=false
           tags: ${{ steps.prep.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,12 +15,12 @@ jobs:
     strategy:
       matrix:
         TIKA_TYPE: [full, minimal]
-        TIKA_VERSION: [1.27, 2.1.0]
+        TIKA_VERSION: [1.28.5, 2.5.0]
         include:
-        - TIKA_VERSION: 2.1.0
+        - TIKA_VERSION: 2.5.0
           TIKA_JAR_NAME: tika-server-standard
           LATEST: true
-        - TIKA_VERSION: 1.27
+        - TIKA_VERSION: 1.28.5
           TIKA_JAR_NAME: tika-server
           LATEST: false
     steps:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -40,8 +40,8 @@ jobs:
             fi
           fi
           # Set output parameters.
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=docker_image::${DOCKER_IMAGE}
+          echo "tags"=${TAGS} >> $GITHUB_OUTPUT
+          echo "docker_image"=${DOCKER_IMAGE} >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
         with:
@@ -51,7 +51,7 @@ jobs:
         id: buildx
         uses: docker/setup-buildx-action@master
 
-      - name: Login to ghcr.io 
+      - name: Login to ghcr.io
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:


### PR DESCRIPTION
- Fixes usage of deprecated output method
- Updates to latest versions for 1.x and 2.x (changes: https://dist.apache.org/repos/dist/release/tika/2.5.0/CHANGES-2.5.0.txt)
- Updates to latest versions of actions
- Adds GitHub Actions caching to the build

I'm also thinking about syncing the Apache upstream changes.  Anyone have thoughts about doing that?

cc: @qcasey @iwishiwasaneagle 