### PR TITLE
Adds a version of the image based on alpine

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,17 +12,23 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  TIKA_JAR_NAME: "tika-server-standard"
+  TIKA_VERSION: "2.7.0"
 jobs:
   docker:
+    name: Build image ${{ matrix.type }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
     strategy:
       matrix:
-        TIKA_TYPE: [full, minimal]
-        TIKA_VERSION: [2.7.0]
+        include:
+          - type: full
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          - type: minimal
+            platforms: linux/amd64,linux/arm64,linux/arm/v7
+          - type: alpine
+            platforms: linux/amd64,linux/arm64
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -33,9 +39,10 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=raw,value=${{ matrix.TIKA_VERSION }}-${{ matrix.TIKA_TYPE }}
-            type=raw,enable=${{ matrix.TIKA_TYPE == 'minimal'}},value=latest
-            type=raw,enable=${{ matrix.TIKA_TYPE == 'full'}},value=latest-full
+            type=raw,value=${{ env.TIKA_VERSION }}-${{ matrix.type }}
+            type=raw,enable=${{ matrix.type == 'minimal'}},value=latest
+            type=raw,enable=${{ matrix.type == 'full'}},value=latest-full
+            type=raw,enable=${{ matrix.type == 'alpine'}},value=latest-alpine
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@master
@@ -59,12 +66,11 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          file: ./${{ matrix.TIKA_TYPE }}/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          file: ./${{ matrix.type }}/Dockerfile
+          platforms: ${{ matrix.platforms }}
           push: true
           build-args: |
-            TIKA_VERSION=${{ matrix.TIKA_VERSION }}
-            TIKA_JAR_NAME=${{ env.TIKA_JAR_NAME }}
+            TIKA_VERSION=${{ env.TIKA_VERSION }}
           tags: ${{ steps.docker-meta.outputs.tags }}
           labels: ${{ steps.docker-meta.outputs.labels }}
           cache-from: type=gha

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,46 @@
+FROM alpine:3.17 as base
+
+FROM base as fetch_tika
+ARG TIKA_VERSION
+ARG CHECK_SIG=true
+
+ENV NEAREST_TIKA_SERVER_URL="https://dlcdn.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    ARCHIVE_TIKA_SERVER_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    BACKUP_TIKA_SERVER_URL="https://downloads.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar" \
+    DEFAULT_TIKA_SERVER_ASC_URL="https://downloads.apache.org/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
+    ARCHIVE_TIKA_SERVER_ASC_URL="https://archive.apache.org/dist/tika/${TIKA_VERSION}/tika-server-standard-${TIKA_VERSION}.jar.asc" \
+    TIKA_VERSION=$TIKA_VERSION
+
+RUN apk add --no-cache \
+        gnupg \
+        wget \
+        ca-certificates \
+    && wget --quiet -t 10 --max-redirect 1 --retry-connrefused -qO- https://downloads.apache.org/tika/KEYS | gpg --import \
+    && wget --quiet -t 10 --max-redirect 1 --retry-connrefused $NEAREST_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget $ARCHIVE_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || wget $BACKUP_TIKA_SERVER_URL -O /tika-server-standard-${TIKA_VERSION}.jar || rm /tika-server-standard-${TIKA_VERSION}.jar \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar ]" || exit 1 \
+    && wget -t 10 --max-redirect 1 --retry-connrefused $DEFAULT_TIKA_SERVER_ASC_URL -O /tika-server-standard-${TIKA_VERSION}.jar.asc  || rm /tika-server-standard-${TIKA_VERSION}.jar.asc \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar.asc ]" || wget --quiet $ARCHIVE_TIKA_SERVER_ASC_URL -O /tika-server-standard-${TIKA_VERSION}.jar.asc || rm /tika-server-standard-${TIKA_VERSION}.jar.asc \
+    && sh -c "[ -f /tika-server-standard-${TIKA_VERSION}.jar.asc ]" || exit 1;
+
+RUN if [ "$CHECK_SIG" = "true" ] ; then gpg --verify /tika-server-standard-${TIKA_VERSION}.jar.asc /tika-server-standard-${TIKA_VERSION}.jar; fi
+
+FROM base as runtime
+ARG UID_GID="35002:35002"
+
+ARG JRE='openjdk17-jre-headless'
+ARG TIKA_VERSION
+
+ENV TIKA_VERSION=$TIKA_VERSION
+
+COPY --from=fetch_tika /tika-server-standard-${TIKA_VERSION}.jar /tika-server-standard-${TIKA_VERSION}.jar
+
+RUN apk add --no-cache \
+        $JRE
+
+USER $UID_GID
+EXPOSE 9998
+ENTRYPOINT [ "/bin/ash", "-c", "exec java -cp \"/tika-server-standard-${TIKA_VERSION}.jar:/tika-extras/*\" org.apache.tika.server.core.TikaServerCli -h 0.0.0.0 $0 $@"]
+
+LABEL maintainer="Apache Tika Developers dev@tika.apache.org"


### PR DESCRIPTION
Basic change, uses the minimal image as inspiration, adds a new image which is based on Alpine Linux.  Over the minimal image, saves about another 100MB of image size.  Appears to work just the same in my own testing.

Alpine doesn't provide an armv7 version for openjdk17-jre-headless, so it's restricted to amd64 and arm64